### PR TITLE
Fixed linker error with liboctree

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -108,7 +108,7 @@ set( SRC_MRSMAPLIB
 
 add_library( mrsmap SHARED ${SRC_MRSMAPLIB} )
 add_definitions( ${SSE_FLAGS} )
-target_link_libraries( mrsmap octreelib ${PCL_LIBRARIES} ${OpenCV_LIBS} ${TBB_LIBRARIES} ${GSL_LIBRARIES} )
+target_link_libraries( mrsmap ${OCTREELIB_LIBRARY} ${PCL_LIBRARIES} ${OpenCV_LIBS} ${TBB_LIBRARIES} ${GSL_LIBRARIES} )
 
 
 

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ MRSMap depends on the following third party libraries:
 - Boost >= 1.54
 - ClooG
 
-Detailed build instructions can be found on https://github.com/ais-hilgert/mrsmap/wiki
+Detailed build instructions can be found on https://github.com/jstueckler/mrsmap/wiki
 
 
 Compile instructions:


### PR DESCRIPTION
liboctree can now be linked, even if its not installed